### PR TITLE
Fixed bug "TypeError: Cannot read property 'forEach' of null"

### DIFF
--- a/routes/block.js
+++ b/routes/block.js
@@ -31,15 +31,17 @@ router.get('/:block', function(req, res, next) {
     block.transactions.forEach(function(tx) {
       tx.traces = [];
       tx.failed = false;
-      traces.forEach(function(trace) {
-        if (tx.hash === trace.transactionHash) {
-          tx.traces.push(trace);
-          if (trace.error) {
-            tx.failed = true;
-            tx.error = trace.error;
+      if (traces != null) {
+        traces.forEach(function(trace) {
+          if (tx.hash === trace.transactionHash) {
+            tx.traces.push(trace);
+            if (trace.error) {
+              tx.failed = true;
+              tx.error = trace.error;
+            }
           }
-        }
-      });
+        });
+      }
       // console.log(tx);
     });
     res.render('block', { block: block });

--- a/routes/tx.js
+++ b/routes/tx.js
@@ -122,16 +122,18 @@ router.get('/:tx', function(req, res, next) {
     tx.traces = [];
     tx.failed = false;
     tx.gasUsed = 0;
+    if (traces != null) {
     traces.forEach(function(trace) {
-      tx.traces.push(trace);
-      if (trace.error) {
-        tx.failed = true;
-        tx.error = trace.error;
-      }
-      if (trace.result && trace.result.gasUsed) {
-        tx.gasUsed += parseInt(trace.result.gasUsed, 16);
-      }
-    });
+        tx.traces.push(trace);
+        if (trace.error) {
+          tx.failed = true;
+          tx.error = trace.error;
+        }
+        if (trace.result && trace.result.gasUsed) {
+          tx.gasUsed += parseInt(trace.result.gasUsed, 16);
+        }
+      });
+    }
     // console.log(tx.traces);
 
     res.render('tx', { tx: tx });


### PR DESCRIPTION
I was getting the error below when clicking on a transaction hash. A simple check to certify that `traces` is not null solved the problem.

```
/home/dnovy/etherchain-light/routes/tx.js:125
    traces.forEach(function(trace) {
          ^
TypeError: Cannot read property 'forEach' of null
    at /home/dnovy/etherchain-light/routes/tx.js:125:11
    at /home/dnovy/etherchain-light/node_modules/async/dist/async.js:421:16
    at next (/home/dnovy/etherchain-light/node_modules/async/dist/async.js:5302:29)
    at /home/dnovy/etherchain-light/node_modules/async/dist/async.js:906:16
    at /home/dnovy/etherchain-light/routes/tx.js:78:9
    at dispatchError (/home/dnovy/etherchain-light/node_modules/levelup/lib/util.js:22:36)
    at /home/dnovy/etherchain-light/node_modules/levelup/lib/levelup.js:203:14
```