### PR TITLE
Update how submodules are cloned

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "utils/solc-bin"]
 	path = utils/solc-bin
-	url = git@github.com:ethereum/solc-bin.git
+	url = https://github.com/ethereum/solc-bin.git


### PR DESCRIPTION
Using `https` instead of `ssh` to clone submodules. Regarding #22